### PR TITLE
fix: increase waitPodRunning timeout 5 -> 10 minutes

### DIFF
--- a/pkg/kubernetes/wait.go
+++ b/pkg/kubernetes/wait.go
@@ -28,7 +28,7 @@ func (k *kubernetesDriver) waitPodRunning(ctx context.Context, id string) (*core
 	nextMessage := time.Now().Add(time.Second * 5)
 
 	var pod *corev1.Pod
-	err := wait.PollImmediate(time.Second, time.Minute*5, func() (bool, error) {
+	err := wait.PollImmediate(time.Second, time.Minute*10, func() (bool, error) {
 		var err error
 		pod, err = k.getPod(ctx, id)
 		now := time.Now()


### PR DESCRIPTION
- cluster autoscalers may take more than 5 minutes currently provided https://github.com/loft-sh/devpod-provider-kubernetes/blob/cfc382d9ef6acd0c85c59026d6d89bc9949b9b65/pkg/kubernetes/wait.go#L31
- see #5
- this is not a resolution to that issue, but provides a sensible patch