### PR TITLE
feat: use PodAffinity to ensure that Workspace pod is scheduled on the same node where Architecture detection was

### DIFF
--- a/pkg/kubernetes/run.go
+++ b/pkg/kubernetes/run.go
@@ -187,14 +187,9 @@ func (k *KubernetesDriver) runContainer(
 	affinity := false
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}
-	// detect if we have an architecture pod running
-	splitId := strings.Split(id, "-")
-	splitId = splitId[:len(splitId)-2]
-
-	affinityLabel := strings.Join(splitId, "-")
 	affinityPod := ""
 
-	err = k.runCommand(ctx, []string{"get", "pods", "-o=name", "-l", "devpod/workspace=" + affinityLabel}, nil, stdout, stderr)
+	err = k.runCommand(ctx, []string{"get", "pods", "-o=name", "-l", "devpod.sh/workspace=" + id}, nil, stdout, stderr)
 	if err != nil {
 		k.Log.Debugf("skipping finding cluster architecture: %s %s %w", stdout.String(), stderr.String(), err)
 	}
@@ -222,9 +217,9 @@ func (k *KubernetesDriver) runContainer(
 				LabelSelector: &metav1.LabelSelector{
 					MatchExpressions: []metav1.LabelSelectorRequirement{
 						{
-							Key:      "devpod/workspace",
+							Key:      "devpod.sh/workspace",
 							Operator: metav1.LabelSelectorOpIn,
-							Values:   []string{affinityLabel},
+							Values:   []string{id},
 						},
 					},
 				},
@@ -262,7 +257,7 @@ func (k *KubernetesDriver) runContainer(
 	// cleanup
 	if affinity {
 		k.Log.Infof("Cleaning up detecting architecture pod: %s", affinityPod)
-		err = k.runCommand(ctx, []string{"delete", "pods", "--force", "-l", "devpod/workspace=" + affinityLabel}, nil, buf, buf)
+		err = k.runCommand(ctx, []string{"delete", "pods", "--force", "-l", "devpod.sh/workspace=" + id}, nil, buf, buf)
 		if err != nil {
 			return errors.Wrapf(err, "cleanup jobs: %s", buf.String())
 		}

--- a/pkg/kubernetes/run.go
+++ b/pkg/kubernetes/run.go
@@ -192,19 +192,19 @@ func (k *KubernetesDriver) runContainer(
 	splitId = splitId[:len(splitId)-2]
 
 	affinityLabel := strings.Join(splitId, "-")
-    affinityPod := ""
+	affinityPod := ""
 
 	err = k.runCommand(ctx, []string{"get", "pods", "-o=name", "-l", "workspace=" + affinityLabel}, nil, stdout, stderr)
 	if err != nil {
 		k.Log.Debugf("skipping finding cluster architecture: %s %s %w", stdout.String(), stderr.String(), err)
 	}
 	if stdout.String() != "" {
-	    affinityPod = strings.TrimSpace(stdout.String())
+		affinityPod = strings.TrimSpace(stdout.String())
 		affinity = true
 	}
 
 	if affinity {
-        k.Log.Infof("Found architecture detecting pod: %s, using PodAffinity...", affinityPod)
+		k.Log.Infof("Found architecture detecting pod: %s, using PodAffinity...", affinityPod)
 		pod.Spec.Affinity = &corev1.Affinity{
 			PodAffinity: &corev1.PodAffinity{
 				RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
@@ -254,7 +254,7 @@ func (k *KubernetesDriver) runContainer(
 
 	// cleanup
 	if affinity {
-        k.Log.Infof("Cleaning up detecting architecture pod: %s", affinityPod)
+		k.Log.Infof("Cleaning up detecting architecture pod: %s", affinityPod)
 		err = k.runCommand(ctx, []string{"delete", "pods", "--force", "-l", "workspace=" + affinityLabel}, nil, buf, buf)
 		if err != nil {
 			return errors.Wrapf(err, "cleanup jobs: %s", buf.String())

--- a/pkg/kubernetes/run.go
+++ b/pkg/kubernetes/run.go
@@ -184,6 +184,48 @@ func (k *KubernetesDriver) runContainer(
 	pod.Spec.Volumes = getVolumes(pod, id)
 	pod.Spec.RestartPolicy = corev1.RestartPolicyNever
 
+	affinity := false
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	// detect if we have an architecture pod running
+	splitId := strings.Split(id, "-")
+	splitId = splitId[:len(splitId)-2]
+
+	affinityLabel := strings.Join(splitId, "-")
+    affinityPod := ""
+
+	err = k.runCommand(ctx, []string{"get", "pods", "-o=name", "-l", "workspace=" + affinityLabel}, nil, stdout, stderr)
+	if err != nil {
+		k.Log.Debugf("skipping finding cluster architecture: %s %s %w", stdout.String(), stderr.String(), err)
+	}
+	if stdout.String() != "" {
+	    affinityPod = strings.TrimSpace(stdout.String())
+		affinity = true
+	}
+
+	if affinity {
+        k.Log.Infof("Found architecture detecting pod: %s, using PodAffinity...", affinityPod)
+		pod.Spec.Affinity = &corev1.Affinity{
+			PodAffinity: &corev1.PodAffinity{
+				RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
+					{
+						LabelSelector: &metav1.LabelSelector{
+							MatchExpressions: []metav1.LabelSelectorRequirement{
+								{
+									Key:      "workspace",
+									Operator: metav1.LabelSelectorOpIn,
+									Values:   []string{affinityLabel},
+								},
+							},
+						},
+						Namespaces:  []string{k.namespace},
+						TopologyKey: "kubernetes.io/hostname",
+					},
+				},
+			},
+		}
+	}
+
 	if k.options.KubernetesPullSecretsEnabled == "true" && pullSecretsCreated {
 		pod.Spec.ImagePullSecrets = []corev1.LocalObjectReference{{Name: getPullSecretsName(id)}}
 	}
@@ -208,6 +250,15 @@ func (k *KubernetesDriver) runContainer(
 	_, err = k.waitPodRunning(ctx, id)
 	if err != nil {
 		return err
+	}
+
+	// cleanup
+	if affinity {
+        k.Log.Infof("Cleaning up detecting architecture pod: %s", affinityPod)
+		err = k.runCommand(ctx, []string{"delete", "pods", "--force", "-l", "workspace=" + affinityLabel}, nil, buf, buf)
+		if err != nil {
+			return errors.Wrapf(err, "cleanup jobs: %s", buf.String())
+		}
 	}
 
 	return nil

--- a/pkg/kubernetes/run.go
+++ b/pkg/kubernetes/run.go
@@ -194,7 +194,7 @@ func (k *KubernetesDriver) runContainer(
 	affinityLabel := strings.Join(splitId, "-")
 	affinityPod := ""
 
-	err = k.runCommand(ctx, []string{"get", "pods", "-o=name", "-l", "workspace=" + affinityLabel}, nil, stdout, stderr)
+	err = k.runCommand(ctx, []string{"get", "pods", "-o=name", "-l", "devpod/workspace=" + affinityLabel}, nil, stdout, stderr)
 	if err != nil {
 		k.Log.Debugf("skipping finding cluster architecture: %s %s %w", stdout.String(), stderr.String(), err)
 	}
@@ -205,25 +205,32 @@ func (k *KubernetesDriver) runContainer(
 
 	if affinity {
 		k.Log.Infof("Found architecture detecting pod: %s, using PodAffinity...", affinityPod)
-		pod.Spec.Affinity = &corev1.Affinity{
-			PodAffinity: &corev1.PodAffinity{
-				RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
-					{
-						LabelSelector: &metav1.LabelSelector{
-							MatchExpressions: []metav1.LabelSelectorRequirement{
-								{
-									Key:      "workspace",
-									Operator: metav1.LabelSelectorOpIn,
-									Values:   []string{affinityLabel},
-								},
-							},
+
+		// ensure we have a pod affinity, and in that case we have, just add ours
+		if pod.Spec.Affinity == nil || pod.Spec.Affinity.PodAffinity == nil {
+			pod.Spec.Affinity = &corev1.Affinity{
+				PodAffinity: &corev1.PodAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{},
+				},
+			}
+		}
+
+		// append our affinity term
+		pod.Spec.Affinity.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution = append(
+			pod.Spec.Affinity.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution,
+			corev1.PodAffinityTerm{
+				LabelSelector: &metav1.LabelSelector{
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						{
+							Key:      "devpod/workspace",
+							Operator: metav1.LabelSelectorOpIn,
+							Values:   []string{affinityLabel},
 						},
-						Namespaces:  []string{k.namespace},
-						TopologyKey: "kubernetes.io/hostname",
 					},
 				},
-			},
-		}
+				Namespaces:  []string{k.namespace},
+				TopologyKey: "kubernetes.io/hostname",
+			})
 	}
 
 	if k.options.KubernetesPullSecretsEnabled == "true" && pullSecretsCreated {
@@ -255,7 +262,7 @@ func (k *KubernetesDriver) runContainer(
 	// cleanup
 	if affinity {
 		k.Log.Infof("Cleaning up detecting architecture pod: %s", affinityPod)
-		err = k.runCommand(ctx, []string{"delete", "pods", "--force", "-l", "workspace=" + affinityLabel}, nil, buf, buf)
+		err = k.runCommand(ctx, []string{"delete", "pods", "--force", "-l", "devpod/workspace=" + affinityLabel}, nil, buf, buf)
 		if err != nil {
 			return errors.Wrapf(err, "cleanup jobs: %s", buf.String())
 		}

--- a/pkg/kubernetes/target_architecture.go
+++ b/pkg/kubernetes/target_architecture.go
@@ -32,7 +32,7 @@ func (k *KubernetesDriver) TargetArchitecture(ctx context.Context, workspaceId s
 	err := k.runCommand(ctx, []string{
 		"run", podName,
 		"-n", k.namespace,
-		"-q", "--rm", "--restart=Never",
+		"-q", "--restart=Never",
 		"--image", k.helperImage(),
 		"--labels", "workspace=" + workspaceId,
 		"--", "sh", "-c", "uname -m && tail -f /dev/null"}, os.Stdin, stdout, stderr)

--- a/pkg/kubernetes/target_architecture.go
+++ b/pkg/kubernetes/target_architecture.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/loft-sh/devpod/pkg/encoding"
@@ -23,11 +24,31 @@ func (k *KubernetesDriver) TargetArchitecture(ctx context.Context, workspaceId s
 		}
 	}
 
-	// get target architecture
+	// get target architnecture
 	k.Log.Infof("Find out cluster architecture...")
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}
-	err := k.runCommand(ctx, []string{"run", "-i", encoding.SafeConcatNameMax([]string{"devpod", workspaceId, random.String(6)}, 32), "-q", "--pod-running-timeout=10m0s", "--rm", "--restart=Never", "--image", k.helperImage(), "--", "sh"}, strings.NewReader("uname -a; exit 0"), stdout, stderr)
+	podName := encoding.SafeConcatNameMax([]string{"devpod", workspaceId, random.String(6)}, 32)
+	err := k.runCommand(ctx, []string{
+	    "run", podName,
+	    "-n", k.namespace,
+	    "-q", "--rm", "--restart=Never",
+	    "--image", k.helperImage(),
+	    "--labels", "workspace=" + workspaceId,
+	    "--", "sh", "-c", "uname -m && tail -f /dev/null"}, os.Stdin, stdout, stderr)
+	if err != nil {
+		return "", fmt.Errorf("find out cluster architecture: %s %s %w", stdout.String(), stderr.String(), err)
+	}
+
+	// wait for pod running
+	k.Log.Infof("Waiting for cluster architecture job to come up...")
+	_, err = k.waitPodRunning(ctx, podName)
+	if err != nil {
+		return "", fmt.Errorf("find out cluster architecture: %s %s %w", stdout.String(), stderr.String(), err)
+	}
+
+	// capture uname output
+	err = k.runCommand(ctx, []string{"logs", podName, "-n", k.namespace}, os.Stdin, stdout, stderr)
 	if err != nil {
 		return "", fmt.Errorf("find out cluster architecture: %s %s %w", stdout.String(), stderr.String(), err)
 	}

--- a/pkg/kubernetes/target_architecture.go
+++ b/pkg/kubernetes/target_architecture.go
@@ -34,7 +34,7 @@ func (k *KubernetesDriver) TargetArchitecture(ctx context.Context, workspaceId s
 		"-n", k.namespace,
 		"-q", "--restart=Never",
 		"--image", k.helperImage(),
-		"--labels", "workspace=" + workspaceId,
+		"--labels", "devpod/workspace=" + workspaceId,
 		"--", "sh", "-c", "uname -m && tail -f /dev/null"}, os.Stdin, stdout, stderr)
 	if err != nil {
 		return "", fmt.Errorf("find out cluster architecture: %s %s %w", stdout.String(), stderr.String(), err)

--- a/pkg/kubernetes/target_architecture.go
+++ b/pkg/kubernetes/target_architecture.go
@@ -34,7 +34,7 @@ func (k *KubernetesDriver) TargetArchitecture(ctx context.Context, workspaceId s
 		"-n", k.namespace,
 		"-q", "--restart=Never",
 		"--image", k.helperImage(),
-		"--labels", "devpod/workspace=" + workspaceId,
+		"--labels", "devpod.sh/workspace=" + workspaceId,
 		"--", "sh", "-c", "uname -m && tail -f /dev/null"}, os.Stdin, stdout, stderr)
 	if err != nil {
 		return "", fmt.Errorf("find out cluster architecture: %s %s %w", stdout.String(), stderr.String(), err)

--- a/pkg/kubernetes/target_architecture.go
+++ b/pkg/kubernetes/target_architecture.go
@@ -30,12 +30,12 @@ func (k *KubernetesDriver) TargetArchitecture(ctx context.Context, workspaceId s
 	stderr := &bytes.Buffer{}
 	podName := encoding.SafeConcatNameMax([]string{"devpod", workspaceId, random.String(6)}, 32)
 	err := k.runCommand(ctx, []string{
-	    "run", podName,
-	    "-n", k.namespace,
-	    "-q", "--rm", "--restart=Never",
-	    "--image", k.helperImage(),
-	    "--labels", "workspace=" + workspaceId,
-	    "--", "sh", "-c", "uname -m && tail -f /dev/null"}, os.Stdin, stdout, stderr)
+		"run", podName,
+		"-n", k.namespace,
+		"-q", "--rm", "--restart=Never",
+		"--image", k.helperImage(),
+		"--labels", "workspace=" + workspaceId,
+		"--", "sh", "-c", "uname -m && tail -f /dev/null"}, os.Stdin, stdout, stderr)
 	if err != nil {
 		return "", fmt.Errorf("find out cluster architecture: %s %s %w", stdout.String(), stderr.String(), err)
 	}


### PR DESCRIPTION
This will ensure they're not scheduled on nodes with different architectures

Basically, if we're scheduling an arch-detection pod, let's use PodAffinity using a labelselector

Fix #4 
Resolves ENG-2042