### PR TITLE
feat: Add support for k8s native sidecars using restartable init containers

### DIFF
--- a/hack/build.sh
+++ b/hack/build.sh
@@ -32,6 +32,10 @@ done
 
 echo "Building version: ${BUILD_VERSION}"
 
+if [[ -z "${GITHUB_REPOSITORY}" ]]; then
+    GITHUB_REPOSITORY="loft-sh/devpod-provider-kubernetes"
+fi
+
 if [[ -z "${PROVIDER_BUILD_PLATFORMS}" ]]; then
     PROVIDER_BUILD_PLATFORMS="linux windows darwin"
 fi
@@ -69,4 +73,4 @@ for OS in ${PROVIDER_BUILD_PLATFORMS[@]}; do
   done
 done
 
-go run -mod vendor "${PROVIDER_ROOT}/hack/provider/main.go" ${RELEASE_VERSION} ${BUILD_VERSION} ${PROVIDER_ROOT} > "${PROVIDER_ROOT}/release/provider.yaml"
+go run -mod vendor "${PROVIDER_ROOT}/hack/provider/main.go" ${RELEASE_VERSION} ${BUILD_VERSION} ${PROVIDER_ROOT} ${GITHUB_REPOSITORY} > "${PROVIDER_ROOT}/release/provider.yaml"

--- a/hack/provider/main.go
+++ b/hack/provider/main.go
@@ -26,8 +26,8 @@ func providerConfigPath(buildVersion string) string {
 }
 
 func main() {
-	if len(os.Args) != 4 {
-		fmt.Fprintln(os.Stderr, "Expected release version, build version and project root as arguments")
+	if len(os.Args) != 5 {
+		fmt.Fprintln(os.Stderr, "Expected release version, build version, project root and GitHub repository as arguments")
 		os.Exit(1)
 		return
 	}
@@ -35,6 +35,7 @@ func main() {
 	releaseVersion := os.Args[1]
 	buildVersion := os.Args[2]
 	projectRoot := os.Args[3]
+	assetRepository := os.Args[4]
 
 	content, err := os.ReadFile(providerConfigPath(buildVersion))
 	if err != nil {
@@ -45,6 +46,8 @@ func main() {
 
 	if buildVersion == "dev" {
 		replaced = strings.Replace(replaced, "##PROJECT_ROOT##", projectRoot, -1)
+	} else {
+		replaced = strings.Replace(replaced, "##ASSET_REPOSITORY##", assetRepository, -1)
 	}
 
 	for k, v := range checksumMap {

--- a/hack/provider/provider.yaml
+++ b/hack/provider/provider.yaml
@@ -131,23 +131,23 @@ agent:
     KUBERNETES_PROVIDER:
       - os: linux
         arch: amd64
-        path: https://github.com/loft-sh/devpod-provider-kubernetes/releases/download/##VERSION##/devpod-provider-kubernetes-linux-amd64
+        path: https://github.com/##ASSET_REPOSITORY##/releases/download/##VERSION##/devpod-provider-kubernetes-linux-amd64
         checksum: ##CHECKSUM_LINUX_AMD64##
       - os: linux
         arch: arm64
-        path: https://github.com/loft-sh/devpod-provider-kubernetes/releases/download/##VERSION##/devpod-provider-kubernetes-linux-arm64
+        path: https://github.com/##ASSET_REPOSITORY##/releases/download/##VERSION##/devpod-provider-kubernetes-linux-arm64
         checksum: ##CHECKSUM_LINUX_ARM64##
       - os: darwin
         arch: amd64
-        path: https://github.com/loft-sh/devpod-provider-kubernetes/releases/download/##VERSION##/devpod-provider-kubernetes-darwin-amd64
+        path: https://github.com/##ASSET_REPOSITORY##/releases/download/##VERSION##/devpod-provider-kubernetes-darwin-amd64
         checksum: ##CHECKSUM_DARWIN_AMD64##
       - os: darwin
         arch: arm64
-        path: https://github.com/loft-sh/devpod-provider-kubernetes/releases/download/##VERSION##/devpod-provider-kubernetes-darwin-arm64
+        path: https://github.com/##ASSET_REPOSITORY##/releases/download/##VERSION##/devpod-provider-kubernetes-darwin-arm64
         checksum: ##CHECKSUM_DARWIN_ARM64##
       - os: windows
         arch: amd64
-        path: https://github.com/loft-sh/devpod-provider-kubernetes/releases/download/##VERSION##/devpod-provider-kubernetes-windows-amd64.exe
+        path: https://github.com/##ASSET_REPOSITORY##/releases/download/##VERSION##/devpod-provider-kubernetes-windows-amd64.exe
         checksum: ##CHECKSUM_WINDOWS_AMD64##
   driver: custom
   custom:

--- a/pkg/kubernetes/container_status.go
+++ b/pkg/kubernetes/container_status.go
@@ -14,6 +14,10 @@ func IsTerminated(status *corev1.ContainerStatus) bool {
 	return status.State.Terminated != nil
 }
 
+func IsStarted(status *corev1.ContainerStatus) bool {
+	return status.Started != nil && *status.Started
+}
+
 func IsRunning(status *corev1.ContainerStatus) bool {
 	return status.State.Running != nil
 }


### PR DESCRIPTION
* Allows devpod provider to work with k8s native sidecars
    * This is done by checking the restart policy on init containers is set to `Always`
    * For all other init containers the default behaviour exists to wait for those to complete
* Improved the provider build script to allow GitHub forks to build and release assets