### PR TITLE
Only override pod affinity

### DIFF
--- a/pkg/kubernetes/run.go
+++ b/pkg/kubernetes/run.go
@@ -237,10 +237,11 @@ func (k *KubernetesDriver) runContainer(
 
 		// ensure we have a pod affinity, and in that case we have, just add ours
 		if pod.Spec.Affinity == nil || pod.Spec.Affinity.PodAffinity == nil {
-			pod.Spec.Affinity = &corev1.Affinity{
-				PodAffinity: &corev1.PodAffinity{
-					RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{},
-				},
+			if pod.Spec.Affinity == nil {
+				pod.Spec.Affinity = &corev1.Affinity{}
+			}
+			pod.Spec.Affinity.PodAffinity = &corev1.PodAffinity{
+				RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{},
 			}
 		}
 


### PR DESCRIPTION
This PR fixes https://github.com/loft-sh/devpod-provider-kubernetes/issues/54 by first checking the affinity and only initialising if it doesn't exist. If an existing node affinity is present (but not a pod affinity) such as the problematic use case, it only overrides the pod affinity.

I tested the PR by building the provider locally and deploying the simple example workspace to a local kind cluster