### PR TITLE
Add tmpfs mount support

### DIFF
--- a/pkg/kubernetes/run.go
+++ b/pkg/kubernetes/run.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -141,6 +142,7 @@ func (k *KubernetesDriver) runContainer(
 	// loop over volume mounts
 	volumeMounts := []corev1.VolumeMount{getVolumeMount(0, mount)}
 	tmpfsVolumes := []corev1.Volume{}
+	fixMountOther(options.Mounts)
 	for idx, mount := range options.Mounts {
 		if mount.Type == "bind" || mount.Type == "volume" {
 			volumeMounts = append(volumeMounts, getVolumeMount(idx+1, mount))
@@ -498,6 +500,47 @@ func getNodeSelector(pod *corev1.Pod, rawNodeSelector string) (map[string]string
 	}
 
 	return nodeSelector, nil
+}
+
+func fixMountOther(mounts []*config.Mount) {
+	raw := os.Getenv("DEVCONTAINER_RUN_OPTIONS")
+	if raw == "" || raw == "null" {
+		return
+	}
+
+	var opts struct {
+		Mounts []json.RawMessage `json:"mounts,omitempty"`
+	}
+	if err := json.Unmarshal([]byte(raw), &opts); err != nil {
+		return
+	}
+
+	for i, rawMount := range opts.Mounts {
+		if i >= len(mounts) {
+			break
+		}
+		// If Other is already populated, nothing to fix.
+		if len(mounts[i].Other) > 0 {
+			continue
+		}
+		// Mounts can be either a JSON string ("source:target:type:...") or a
+		// JSON object. Only the object form is affected by the upstream bug —
+		// the string form goes through ParseMount which handles Other. So
+		// skip anything that isn't a JSON object.
+		var obj map[string]json.RawMessage
+		if err := json.Unmarshal(rawMount, &obj); err != nil {
+			continue
+		}
+		otherRaw, ok := obj["other"]
+		if !ok {
+			continue
+		}
+		var others []string
+		if err := json.Unmarshal(otherRaw, &others); err != nil {
+			continue
+		}
+		mounts[i].Other = others
+	}
 }
 
 func (k *KubernetesDriver) StartDevContainer(ctx context.Context, workspaceId string) error {

--- a/pkg/kubernetes/run.go
+++ b/pkg/kubernetes/run.go
@@ -140,10 +140,13 @@ func (k *KubernetesDriver) runContainer(
 
 	// loop over volume mounts
 	volumeMounts := []corev1.VolumeMount{getVolumeMount(0, mount)}
+	tmpfsVolumes := []corev1.Volume{}
 	for idx, mount := range options.Mounts {
-		volumeMount := getVolumeMount(idx+1, mount)
 		if mount.Type == "bind" || mount.Type == "volume" {
-			volumeMounts = append(volumeMounts, volumeMount)
+			volumeMounts = append(volumeMounts, getVolumeMount(idx+1, mount))
+		} else if mount.Type == "tmpfs" {
+			volumeMounts = append(volumeMounts, getTmpfsVolumeMount(mount))
+			tmpfsVolumes = append(tmpfsVolumes, getTmpfsVolume(mount))
 		} else {
 			k.Log.Warnf("Unsupported mount type '%s' in mount '%s', will skip", mount.Type, mount.String())
 		}
@@ -218,7 +221,7 @@ func (k *KubernetesDriver) runContainer(
 	pod.Spec.NodeSelector = nodeSelector
 	pod.Spec.InitContainers = initContainers
 	pod.Spec.Containers = getContainers(pod, options.Image, options.Entrypoint, options.Cmd, envVars, volumeMounts, capabilities, resources, options.Privileged, k.options.DangerouslyOverrideImage, k.options.StrictSecurity)
-	pod.Spec.Volumes = getVolumes(pod, id)
+	pod.Spec.Volumes = getVolumes(pod, id, tmpfsVolumes)
 
 	affinity := false
 	stdout := &bytes.Buffer{}
@@ -418,7 +421,7 @@ func getContainers(
 	return retContainers
 }
 
-func getVolumes(pod *corev1.Pod, id string) []corev1.Volume {
+func getVolumes(pod *corev1.Pod, id string, tmpfsVolumes []corev1.Volume) []corev1.Volume {
 	volumes := []corev1.Volume{
 		{
 			Name: "devpod",
@@ -429,6 +432,8 @@ func getVolumes(pod *corev1.Pod, id string) []corev1.Volume {
 			},
 		},
 	}
+
+	volumes = append(volumes, tmpfsVolumes...)
 
 	if pod.Spec.Volumes != nil {
 		volumes = append(volumes, pod.Spec.Volumes...)

--- a/pkg/kubernetes/tmpfs.go
+++ b/pkg/kubernetes/tmpfs.go
@@ -1,0 +1,144 @@
+package kubernetes
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/loft-sh/devpod/pkg/devcontainer/config"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+// maxK8sNameLength is the maximum length for a Kubernetes resource name.
+// See: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/
+const maxK8sNameLength = 63
+
+// slugifyVolumeName converts a mount target path into a Kubernetes-safe
+// volume name segment. It is intended to be used as a suffix, not a
+// complete volume name.
+//
+// The rules are:
+//  1. Strip leading and trailing `/`
+//  2. Replace `/` with `-`
+//  3. Strip all characters not in `[a-z0-9-]`
+//  4. Collapse consecutive dashes
+//  5. Truncate to 63 characters if needed
+func slugifyVolumeName(target string) string {
+	// 1. Strip leading and trailing slashes
+	target = strings.Trim(target, "/")
+
+	// 2. Replace slashes with dashes
+	target = strings.ReplaceAll(target, "/", "-")
+
+	// 3. Strip characters not in [a-z0-9-]
+	//    We iterate runes to be safe with multi-byte characters.
+	var b strings.Builder
+	b.Grow(len(target))
+	for _, r := range strings.ToLower(target) {
+		switch {
+		case r >= 'a' && r <= 'z':
+			b.WriteRune(r)
+		case r >= '0' && r <= '9':
+			b.WriteRune(r)
+		case r == '-':
+			b.WriteRune(r)
+		default:
+			// drop character
+		}
+	}
+	cleaned := b.String()
+
+	// 4. Collapse consecutive dashes
+	for strings.Contains(cleaned, "--") {
+		cleaned = strings.ReplaceAll(cleaned, "--", "-")
+	}
+	cleaned = strings.Trim(cleaned, "-")
+
+	// 5. Truncate to 63 chars
+	if len(cleaned) > maxK8sNameLength {
+		cleaned = cleaned[:maxK8sNameLength]
+		// Re-trim trailing dashes in case truncation cut a double dash
+		cleaned = strings.TrimRight(cleaned, "-")
+	}
+
+	return cleaned
+}
+
+// parseTmpfsSize extracts the optional `size=` value from a mount's
+// `Other` field and parses it as a Kubernetes resource.Quantity.
+//
+// Returns (nil, nil) when no `size=` entry is present.
+// Returns an error when a `size=` entry is present but cannot be parsed.
+func parseTmpfsSize(mount *config.Mount) (*resource.Quantity, error) {
+	if mount == nil {
+		return nil, nil
+	}
+
+	const prefix = "size="
+	var sizeStr string
+	found := false
+	for _, entry := range mount.Other {
+		if strings.HasPrefix(entry, prefix) {
+			sizeStr = strings.TrimPrefix(entry, prefix)
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		return nil, nil
+	}
+
+	if sizeStr == "" {
+		return nil, fmt.Errorf("empty size value in mount '%s'", mount.String())
+	}
+
+	quantity, err := resource.ParseQuantity(sizeStr)
+	if err != nil {
+		return nil, fmt.Errorf("parse tmpfs size %q for mount '%s': %w", sizeStr, mount.String(), err)
+	}
+
+	return &quantity, nil
+}
+
+// getTmpfsVolumeName returns the volume name to use for a tmpfs mount.
+// If the mount has an explicit `source`, that source is used directly
+// (prefixed with `devpod-`). Otherwise the slugified target is used.
+func getTmpfsVolumeName(mount *config.Mount) string {
+	if mount.Source != "" {
+		return "devpod-" + mount.Source
+	}
+	return "devpod-" + slugifyVolumeName(mount.Target)
+}
+
+// getTmpfsVolume returns a Kubernetes Volume describing the tmpfs mount
+// as an in-memory emptyDir. An optional sizeLimit is set when the
+// mount's `Other` field includes a parseable `size=` entry.
+func getTmpfsVolume(mount *config.Mount) corev1.Volume {
+	emptyDir := &corev1.EmptyDirVolumeSource{
+		Medium: corev1.StorageMediumMemory,
+	}
+
+	if quantity, err := parseTmpfsSize(mount); err != nil {
+		// Skip sizeLimit on parse error — caller is expected to log.
+		_ = quantity
+	} else if quantity != nil {
+		emptyDir.SizeLimit = quantity
+	}
+
+	return corev1.Volume{
+		Name: getTmpfsVolumeName(mount),
+		VolumeSource: corev1.VolumeSource{
+			EmptyDir: emptyDir,
+		},
+	}
+}
+
+// getTmpfsVolumeMount returns the VolumeMount that mounts a tmpfs
+// volume into a container at the mount's target path.
+func getTmpfsVolumeMount(mount *config.Mount) corev1.VolumeMount {
+	return corev1.VolumeMount{
+		Name:      getTmpfsVolumeName(mount),
+		MountPath: mount.Target,
+	}
+}

--- a/pkg/kubernetes/tmpfs_test.go
+++ b/pkg/kubernetes/tmpfs_test.go
@@ -1,0 +1,422 @@
+package kubernetes
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/loft-sh/devpod/pkg/devcontainer/config"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestSlugifyVolumeName(t *testing.T) {
+	tests := []struct {
+		name   string
+		target string
+		want   string
+	}{
+		{
+			name:   "standard dev shm path",
+			target: "/dev/shm",
+			want:   "dev-shm",
+		},
+		{
+			name:   "tmp cache path",
+			target: "/tmp/cache",
+			want:   "tmp-cache",
+		},
+		{
+			name:   "home user dotfile path",
+			target: "/home/user/.npm",
+			want:   "home-user-npm",
+		},
+		{
+			name:   "root path edge case returns empty",
+			target: "/",
+			want:   "",
+		},
+		{
+			name:   "consecutive slashes collapse",
+			target: "/tmp//cache///data",
+			want:   "tmp-cache-data",
+		},
+		{
+			name:   "consecutive dashes collapse",
+			target: "/foo---bar",
+			want:   "foo-bar",
+		},
+		{
+			name:   "special characters are stripped",
+			target: "/path/with@special!chars#",
+			want:   "path-withspecialchars",
+		},
+		{
+			name:   "uppercase is lowercased",
+			target: "/Home/User/Documents",
+			want:   "home-user-documents",
+		},
+		{
+			name:   "leading and trailing slashes stripped",
+			target: "///foo///",
+			want:   "foo",
+		},
+		{
+			name:   "truncation at 63 chars",
+			target: "/" + strings.Repeat("a", 100),
+			want:   strings.Repeat("a", 63),
+		},
+		{
+			name:   "no slashes returns sanitized string",
+			target: "myvolume",
+			want:   "myvolume",
+		},
+		{
+			name:   "underscores are stripped",
+			target: "/var/lib_data",
+			want:   "var-libdata",
+		},
+		{
+			name:   "only special characters returns empty",
+			target: "/@!#",
+			want:   "",
+		},
+		{
+			name:   "truncation cuts at a dash and re-trims",
+			// 62 'a's + "--x" → after collapse → 62 'a's + "-x" (64 chars)
+			// truncate to 63 → 62 'a's + "-" → re-trim trailing dash → 62 'a's
+			target: "/" + strings.Repeat("a", 62) + "--x",
+			want:   strings.Repeat("a", 62),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := slugifyVolumeName(tt.target)
+			if got != tt.want {
+				t.Errorf("slugifyVolumeName(%q) = %q, want %q", tt.target, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSlugifyVolumeName_MaxLength(t *testing.T) {
+	// Defensive: the result must never exceed 63 characters regardless of input.
+	inputs := []string{
+		"/" + strings.Repeat("a", 200),
+		"/" + strings.Repeat("a", 60) + "-" + strings.Repeat("b", 200),
+		"/" + strings.Repeat("a-", 100),
+	}
+	for _, in := range inputs {
+		got := slugifyVolumeName(in)
+		if len(got) > maxK8sNameLength {
+			t.Errorf("slugifyVolumeName(%q) length = %d, want <= %d", in, len(got), maxK8sNameLength)
+		}
+	}
+}
+
+func TestParseTmpfsSize(t *testing.T) {
+	t.Run("size with Gi suffix", func(t *testing.T) {
+		mount := &config.Mount{
+			Type:   "tmpfs",
+			Target: "/dev/shm",
+			Other:  []string{"size=1Gi"},
+		}
+		got, err := parseTmpfsSize(mount)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got == nil {
+			t.Fatal("expected quantity, got nil")
+		}
+		if got.String() != "1Gi" {
+			t.Errorf("got = %s, want 1Gi", got.String())
+		}
+	})
+
+	t.Run("size with Mi suffix", func(t *testing.T) {
+		mount := &config.Mount{
+			Type:   "tmpfs",
+			Target: "/dev/shm",
+			Other:  []string{"size=512Mi"},
+		}
+		got, err := parseTmpfsSize(mount)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got == nil {
+			t.Fatal("expected quantity, got nil")
+		}
+		if got.String() != "512Mi" {
+			t.Errorf("got = %s, want 512Mi", got.String())
+		}
+	})
+
+	t.Run("size as plain bytes", func(t *testing.T) {
+		mount := &config.Mount{
+			Type:   "tmpfs",
+			Target: "/dev/shm",
+			Other:  []string{"size=1073741824"},
+		}
+		got, err := parseTmpfsSize(mount)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got == nil {
+			t.Fatal("expected quantity, got nil")
+		}
+		if got.String() != "1073741824" {
+			t.Errorf("got = %s, want 1073741824", got.String())
+		}
+	})
+
+	t.Run("no size returns nil no error", func(t *testing.T) {
+		mount := &config.Mount{
+			Type:   "tmpfs",
+			Target: "/dev/shm",
+		}
+		got, err := parseTmpfsSize(mount)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != nil {
+			t.Errorf("expected nil, got %v", got)
+		}
+	})
+
+	t.Run("no size with other entries returns nil no error", func(t *testing.T) {
+		mount := &config.Mount{
+			Type:   "tmpfs",
+			Target: "/dev/shm",
+			Other:  []string{"ro", "nosuid"},
+		}
+		got, err := parseTmpfsSize(mount)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != nil {
+			t.Errorf("expected nil, got %v", got)
+		}
+	})
+
+	t.Run("invalid size returns error", func(t *testing.T) {
+		mount := &config.Mount{
+			Type:   "tmpfs",
+			Target: "/dev/shm",
+			Other:  []string{"size=not-a-quantity"},
+		}
+		got, err := parseTmpfsSize(mount)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if got != nil {
+			t.Errorf("expected nil quantity on error, got %v", got)
+		}
+	})
+
+	t.Run("size= is picked up among multiple other entries", func(t *testing.T) {
+		mount := &config.Mount{
+			Type:   "tmpfs",
+			Target: "/dev/shm",
+			Other:  []string{"ro", "size=2Gi", "nosuid"},
+		}
+		got, err := parseTmpfsSize(mount)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got == nil {
+			t.Fatal("expected quantity, got nil")
+		}
+		if got.String() != "2Gi" {
+			t.Errorf("got = %s, want 2Gi", got.String())
+		}
+	})
+
+	t.Run("empty size value returns error", func(t *testing.T) {
+		mount := &config.Mount{
+			Type:   "tmpfs",
+			Target: "/dev/shm",
+			Other:  []string{"size="},
+		}
+		if _, err := parseTmpfsSize(mount); err == nil {
+			t.Fatal("expected error for empty size value, got nil")
+		}
+	})
+
+	t.Run("nil mount returns nil no error", func(t *testing.T) {
+		got, err := parseTmpfsSize(nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != nil {
+			t.Errorf("expected nil, got %v", got)
+		}
+	})
+}
+
+func TestGetTmpfsVolumeName(t *testing.T) {
+	t.Run("with source uses source directly", func(t *testing.T) {
+		mount := &config.Mount{
+			Type:   "tmpfs",
+			Source: "mycache",
+			Target: "/cache",
+		}
+		got := getTmpfsVolumeName(mount)
+		if got != "devpod-mycache" {
+			t.Errorf("got = %q, want %q", got, "devpod-mycache")
+		}
+	})
+
+	t.Run("without source uses slugified target", func(t *testing.T) {
+		mount := &config.Mount{
+			Type:   "tmpfs",
+			Target: "/dev/shm",
+		}
+		got := getTmpfsVolumeName(mount)
+		if got != "devpod-dev-shm" {
+			t.Errorf("got = %q, want %q", got, "devpod-dev-shm")
+		}
+	})
+
+	t.Run("with empty source falls back to slugified target", func(t *testing.T) {
+		mount := &config.Mount{
+			Type:   "tmpfs",
+			Source: "",
+			Target: "/tmp/cache",
+		}
+		got := getTmpfsVolumeName(mount)
+		if got != "devpod-tmp-cache" {
+			t.Errorf("got = %q, want %q", got, "devpod-tmp-cache")
+		}
+	})
+
+	t.Run("with source and deep target still uses source", func(t *testing.T) {
+		mount := &config.Mount{
+			Type:   "tmpfs",
+			Source: "fast",
+			Target: "/var/lib/data/something/deep",
+		}
+		got := getTmpfsVolumeName(mount)
+		if got != "devpod-fast" {
+			t.Errorf("got = %q, want %q", got, "devpod-fast")
+		}
+	})
+}
+
+func TestGetTmpfsVolume(t *testing.T) {
+	t.Run("with size sets sizeLimit and Memory medium", func(t *testing.T) {
+		mount := &config.Mount{
+			Type:   "tmpfs",
+			Target: "/dev/shm",
+			Other:  []string{"size=1Gi"},
+		}
+		vol := getTmpfsVolume(mount)
+
+		if vol.Name != "devpod-dev-shm" {
+			t.Errorf("vol.Name = %q, want %q", vol.Name, "devpod-dev-shm")
+		}
+		if vol.EmptyDir == nil {
+			t.Fatal("vol.EmptyDir is nil")
+		}
+		if vol.EmptyDir.Medium != corev1.StorageMediumMemory {
+			t.Errorf("Medium = %q, want %q", vol.EmptyDir.Medium, corev1.StorageMediumMemory)
+		}
+		if vol.EmptyDir.SizeLimit == nil {
+			t.Fatal("SizeLimit is nil, want set")
+		}
+		if vol.EmptyDir.SizeLimit.String() != "1Gi" {
+			t.Errorf("SizeLimit = %s, want 1Gi", vol.EmptyDir.SizeLimit.String())
+		}
+	})
+
+	t.Run("without size leaves sizeLimit nil and medium Memory", func(t *testing.T) {
+		mount := &config.Mount{
+			Type:   "tmpfs",
+			Target: "/dev/shm",
+		}
+		vol := getTmpfsVolume(mount)
+
+		if vol.Name != "devpod-dev-shm" {
+			t.Errorf("vol.Name = %q, want %q", vol.Name, "devpod-dev-shm")
+		}
+		if vol.EmptyDir == nil {
+			t.Fatal("vol.EmptyDir is nil")
+		}
+		if vol.EmptyDir.Medium != corev1.StorageMediumMemory {
+			t.Errorf("Medium = %q, want %q", vol.EmptyDir.Medium, corev1.StorageMediumMemory)
+		}
+		if vol.EmptyDir.SizeLimit != nil {
+			t.Errorf("SizeLimit = %v, want nil", vol.EmptyDir.SizeLimit)
+		}
+	})
+
+	t.Run("with invalid size leaves sizeLimit nil", func(t *testing.T) {
+		mount := &config.Mount{
+			Type:   "tmpfs",
+			Target: "/dev/shm",
+			Other:  []string{"size=garbage"},
+		}
+		vol := getTmpfsVolume(mount)
+
+		if vol.EmptyDir == nil {
+			t.Fatal("vol.EmptyDir is nil")
+		}
+		if vol.EmptyDir.Medium != corev1.StorageMediumMemory {
+			t.Errorf("Medium = %q, want %q", vol.EmptyDir.Medium, corev1.StorageMediumMemory)
+		}
+		if vol.EmptyDir.SizeLimit != nil {
+			t.Errorf("SizeLimit = %v, want nil (parse error should skip size)", vol.EmptyDir.SizeLimit)
+		}
+	})
+
+	t.Run("with source uses source for volume name", func(t *testing.T) {
+		mount := &config.Mount{
+			Type:   "tmpfs",
+			Source: "mycache",
+			Target: "/cache",
+			Other:  []string{"size=512Mi"},
+		}
+		vol := getTmpfsVolume(mount)
+		if vol.Name != "devpod-mycache" {
+			t.Errorf("vol.Name = %q, want %q", vol.Name, "devpod-mycache")
+		}
+	})
+}
+
+func TestGetTmpfsVolumeMount(t *testing.T) {
+	t.Run("mount path and name match mount", func(t *testing.T) {
+		mount := &config.Mount{
+			Type:   "tmpfs",
+			Target: "/dev/shm",
+		}
+		vm := getTmpfsVolumeMount(mount)
+
+		if vm.Name != "devpod-dev-shm" {
+			t.Errorf("vm.Name = %q, want %q", vm.Name, "devpod-dev-shm")
+		}
+		if vm.MountPath != "/dev/shm" {
+			t.Errorf("vm.MountPath = %q, want %q", vm.MountPath, "/dev/shm")
+		}
+		if vm.SubPath != "" {
+			t.Errorf("vm.SubPath = %q, want empty", vm.SubPath)
+		}
+	})
+
+	t.Run("mount name matches getTmpfsVolume name with source", func(t *testing.T) {
+		mount := &config.Mount{
+			Type:   "tmpfs",
+			Source: "shared",
+			Target: "/tmp/shared",
+		}
+		vm := getTmpfsVolumeMount(mount)
+		vol := getTmpfsVolume(mount)
+
+		if vm.Name != vol.Name {
+			t.Errorf("mount name %q does not match volume name %q", vm.Name, vol.Name)
+		}
+		if vm.Name != "devpod-shared" {
+			t.Errorf("vm.Name = %q, want %q", vm.Name, "devpod-shared")
+		}
+		if vm.MountPath != "/tmp/shared" {
+			t.Errorf("vm.MountPath = %q, want %q", vm.MountPath, "/tmp/shared")
+		}
+	})
+}


### PR DESCRIPTION
## Summary

This PR adds support for `tmpfs`-type mounts in the Kubernetes devpod provider. Tmpfs mounts are mapped to Kubernetes `emptyDir` volumes backed by memory (`StorageMediumMemory`), with optional size limits. A workaround is included to correctly populate the `Other` field on mounts (needed for size limits to work), since the upstream parser drops it for JSON object-form mount entries.

## What's happening

- A new `tmpfs.go` module provides helpers to build Kubernetes `emptyDir` volumes (memory-backed) and volume mounts from tmpfs mount definitions. Volume names are derived from the mount's `source` field when provided (e.g. `source=myshm` → volume name `devpod-myshm`), or from a slugified target path as a fallback. An optional `size=` parameter is parsed as a Kubernetes `resource.Quantity` and applied as `sizeLimit`.
- `run.go` is updated to recognize `tmpfs` mount types alongside existing `bind`/`volume` types and thread the resulting volumes into the pod spec.
- A `fixMountOther` function works around an upstream issue where the `Other` field on mounts is lost during deserialization — this is what carries the `size=` option, so the workaround is needed for size limits to take effect.
- Comprehensive table-driven unit tests cover slugification edge cases, size parsing, volume naming, and full volume/mount generation.

## Example

A devcontainer `mounts` entry like:

```
"type=tmpfs,target=/dev/shm,size=1Gi"
```

Produces a pod spec with:

```yaml
volumes:
  - name: devpod-dev-shm
    emptyDir:
      medium: Memory
      sizeLimit: 1Gi
volumeMounts:
  - name: devpod-dev-shm
    mountPath: /dev/shm
```

## Disclaimer: Was AI used in this PR?

I used AI to aid me in the development of this PR, however I was always in the loop and fully tested this myself and manually reviewed the code. While I am an experienced dev, GO is not in my language repertoire so AI helped :P